### PR TITLE
Ignore pgp_key changes for aws_iam_access_key in iam-user

### DIFF
--- a/modules/iam-user/credentials.tf
+++ b/modules/iam-user/credentials.tf
@@ -32,6 +32,12 @@ resource "aws_iam_access_key" "this" {
   pgp_key = var.pgp_key
 
   status = try(var.access_keys[count.index].enabled, true) ? "Active" : "Inactive"
+
+  lifecycle {
+    ignore_changes = [
+      pgp_key,
+    ]
+  }
 }
 
 


### PR DESCRIPTION
### Background

- Ignore changes of `pgp_key` for `aws_iam_access_key` resource in `iam-user` module