### PR TITLE
Support to configure session_duration in seconds for sso-permission-set module

### DIFF
--- a/modules/sso-account-assignment/variables.tf
+++ b/modules/sso-account-assignment/variables.tf
@@ -1,21 +1,21 @@
 variable "account_id" {
-  description = "The identifier of an AWS account which the assignment willb e created. Typically a 10-12 digit string."
+  description = "(Required) The identifier of an AWS account which the assignment willb e created. Typically a 10-12 digit string."
   type        = string
 }
 
 variable "permission_set_arn" {
-  description = "The ARN of the Permission Set that the admin wants to grant the principal access to."
+  description = "(Required) The ARN of the Permission Set that the admin wants to grant the principal access to."
   type        = string
 }
 
 variable "groups" {
-  description = "List of names of Group entities who can access to the Permission Set."
+  description = "(Optional) List of names of Group entities who can access to the Permission Set."
   type        = list(string)
   default     = []
 }
 
 variable "users" {
-  description = "List of names of User entities who can access to the Permission Set."
+  description = "(Optional) List of names of User entities who can access to the Permission Set."
   type        = list(string)
   default     = []
 }

--- a/modules/sso-account-assignment/versions.tf
+++ b/modules/sso-account-assignment/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.2"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.45"
+      version = ">= 4.22"
     }
   }
 }

--- a/modules/sso-permission-set/outputs.tf
+++ b/modules/sso-permission-set/outputs.tf
@@ -14,7 +14,7 @@ output "instance_arn" {
 }
 
 output "session_duration" {
-  description = "The length of time that the application user sessions are valid in the ISO-8601 standard."
+  description = "The length of time that the application user sessions are valid in seconds."
   value       = aws_ssoadmin_permission_set.this.session_duration
 }
 

--- a/modules/sso-permission-set/variables.tf
+++ b/modules/sso-permission-set/variables.tf
@@ -1,48 +1,62 @@
 variable "name" {
-  description = "The name of the Permission Set."
+  description = "(Required) The name of the Permission Set."
   type        = string
+  nullable    = false
 }
 
 variable "description" {
-  description = "The description of the Permission Set."
+  description = "(Optional) The description of the Permission Set."
   type        = string
   default     = "Managed by Terraform."
+  nullable    = false
 }
 
 variable "session_duration" {
-  description = "The length of time that the application user sessions are valid in the ISO-8601 standard."
-  type        = string
-  default     = "PT1H"
+  description = "(Optional) The length of time that the application user sessions are valid in seconds. Duration should be a number between `3600` (1 hour) and `43200` (12 hours)."
+  type        = number
+  default     = 3600
+  nullable    = false
+
+  validation {
+    condition = alltrue([
+      var.session_duration >= 3600,
+      var.session_duration <= 43200
+    ])
+    error_message = "The value of session duration should be a number between 3600 (1 hour) and 43200 (12 hours)."
+  }
 }
 
 variable "relay_state" {
-  description = "The relay state URL used to redirect users within the application during the federation authentication process."
+  description = "(Optional) The relay state URL used to redirect users within the application during the federation authentication process."
   type        = string
   default     = null
 }
 
 variable "managed_policies" {
-  description = "List of ARNs of IAM managed policies to be attached to the Permission Set."
+  description = "(Optional) List of ARNs of IAM managed policies to be attached to the Permission Set."
   type        = list(string)
   default     = []
+  nullable    = false
 }
 
 variable "inline_policy" {
-  description = "The IAM inline policy to attach to a Permission Set. Only supports one IAM inline policy per Permission Set. Creating or updating this resource will automatically Provision the Permission Set to apply the corresponding updates to all assigned accounts."
+  description = "(Optional) The IAM inline policy to attach to a Permission Set. Only supports one IAM inline policy per Permission Set. Creating or updating this resource will automatically Provision the Permission Set to apply the corresponding updates to all assigned accounts."
   type        = string
   default     = null
 }
 
 variable "tags" {
-  description = "A map of tags to add to all resources."
+  description = "(Optional) A map of tags to add to all resources."
   type        = map(string)
   default     = {}
+  nullable    = false
 }
 
 variable "module_tags_enabled" {
-  description = "Whether to create AWS Resource Tags for the module informations."
+  description = "(Optional) Whether to create AWS Resource Tags for the module informations."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 
@@ -51,19 +65,22 @@ variable "module_tags_enabled" {
 ###################################################
 
 variable "resource_group_enabled" {
-  description = "Whether to create Resource Group to find and group AWS resources which are created by this module."
+  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "resource_group_name" {
-  description = "The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
+  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
   type        = string
   default     = ""
+  nullable    = false
 }
 
 variable "resource_group_description" {
-  description = "The description of Resource Group."
+  description = "(Optional) The description of Resource Group."
   type        = string
   default     = "Managed by Terraform."
+  nullable    = false
 }


### PR DESCRIPTION
### Background

- Support to configure `session_duration` in seconds for `sso-permission-set` module

### Example

```hcl
module "permission_set" {
  source  = "tedilabs/account/aws//modules/sso-permission-set"

  name        = "test"
  description = "Managed by Teraform."

  session_duration = 3940
  relay_state      = "https://ap-northeast-2.console.aws.amazon.com"

  managed_policies = ["AdministratorAccess"]
}
```