### PR TITLE
Support fms delegated administrator for org-account module

### DIFF
--- a/modules/org-account/README.md
+++ b/modules/org-account/README.md
@@ -6,6 +6,7 @@ This module creates following resources.
 - `aws_organizations_policy_attachment` (optional)
 - `aws_organizations_delegated_administrator` (optional)
 - `aws_macie2_organization_admin_account` (optional)
+- `aws_fms_admin_account` (optional)
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements

--- a/modules/org-account/delegated-administrators.tf
+++ b/modules/org-account/delegated-administrators.tf
@@ -1,3 +1,9 @@
+locals {
+  independent_services = [
+    "fms.amazonaws.com",
+    "macie.amazonaws.com",
+  ]
+}
 
 
 ###################################################
@@ -8,7 +14,7 @@ resource "aws_organizations_delegated_administrator" "this" {
   for_each = toset([
     for service in var.delegated_services :
     service
-    if !contains(["macie.amazonaws.com"], service)
+    if !contains(local.independent_services, service)
   ])
 
   account_id        = aws_organizations_account.this.id
@@ -17,5 +23,12 @@ resource "aws_organizations_delegated_administrator" "this" {
 
 resource "aws_macie2_organization_admin_account" "this" {
   count = contains(var.delegated_services, "macie.amazonaws.com") ? 1 : 0
+
   admin_account_id = aws_organizations_account.this.id
+}
+
+resource "aws_fms_admin_account" "this" {
+  count = contains(var.delegated_services, "fms.amazonaws.com") ? 1 : 0
+
+  account_id = aws_organizations_account.this.id
 }


### PR DESCRIPTION
### Background

- Support `fms.amazonaws.com` delegated service for `org-account` module.