### PR TITLE
Unify ec2 spot datafeed subscription variables in account module

### DIFF
--- a/modules/account/ec2.tf
+++ b/modules/account/ec2.tf
@@ -5,8 +5,8 @@
 # INFO: Need permission to S3 ACL
 # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-data-feeds.html#using-spot-instances-dfs3
 resource "aws_spot_datafeed_subscription" "this" {
-  count = var.ec2_spot_datafeed_subscription_enabled ? 1 : 0
+  count = var.ec2_spot_datafeed_subscription.enabled ? 1 : 0
 
-  bucket = var.ec2_spot_datafeed_subscription_s3_bucket
-  prefix = var.ec2_spot_datafeed_subscription_s3_prefix
+  bucket = var.ec2_spot_datafeed_subscription.s3_bucket.name
+  prefix = var.ec2_spot_datafeed_subscription.s3_bucket.key_prefix
 }

--- a/modules/account/outputs.tf
+++ b/modules/account/outputs.tf
@@ -55,7 +55,7 @@ output "ec2" {
   EOF
   value = {
     spot_datafeed_subscription = {
-      enabled = var.ec2_spot_datafeed_subscription_enabled
+      enabled = var.ec2_spot_datafeed_subscription.enabled
       s3 = {
         bucket = one(aws_spot_datafeed_subscription.this[*].bucket)
         prefix = one(aws_spot_datafeed_subscription.this[*].prefix)

--- a/modules/account/variables.tf
+++ b/modules/account/variables.tf
@@ -57,25 +57,23 @@ variable "security_contact" {
   default  = null
 }
 
-variable "ec2_spot_datafeed_subscription_enabled" {
-  description = "(Optional) Indicates whether to enable Spot Data Feed Subscription to S3 Bucket. Defaults to `false`."
-  type        = bool
-  default     = false
-  nullable    = false
-}
-
-variable "ec2_spot_datafeed_subscription_s3_bucket" {
-  description = "(Optional) The name of the S3 bucket to deliver Spot Data Feed to."
-  type        = string
-  default     = ""
-  nullable    = false
-}
-
-variable "ec2_spot_datafeed_subscription_s3_prefix" {
-  description = "(Optional) The path of directory inside S3 bucket to place spot pricing data."
-  type        = string
-  default     = ""
-  nullable    = false
+variable "ec2_spot_datafeed_subscription" {
+  description = <<EOF
+  (Optional) The configuration of the Spot Data Feed Subscription. `ec2_spot_datafeed_subscription` as defined below.
+    (Optional) `enabled` - Indicate whether to enable Spot Data Feed Subscription to S3 Bucket. Defaults to `false`.
+    (Optional) `s3_bucket` - The configuration of the S3 bucket where AWS deliver the spot data feed. `s3_bucket` as defined below.
+      (Required) `name` - The name of the S3 bucket where AWS deliver the spot data feed.
+      (Optional) `key_prefix` - The path of directory inside S3 bucket to place spot pricing data.
+  EOF
+  type = object({
+    enabled = optional(bool, false)
+    s3_bucket = optional(object({
+      name       = optional(string, "")
+      key_prefix = optional(string, "")
+    }))
+  })
+  default  = {}
+  nullable = false
 }
 
 variable "s3_public_access_enabled" {


### PR DESCRIPTION
### :wave: Background
<!-- Please explain the background or motivation for this change. -->

- Unify ec2 spot datafeed subscription variables in account module