### PR TITLE
Support support-app slack in account module

### DIFF
--- a/modules/account/README.md
+++ b/modules/account/README.md
@@ -18,12 +18,14 @@ This module creates following resources.
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.10 |
+| <a name="requirement_awscc"></a> [awscc](#requirement\_awscc) | >= 0.75 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.19.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.47.0 |
+| <a name="provider_awscc"></a> [awscc](#provider\_awscc) | 0.75.0 |
 
 ## Modules
 
@@ -37,11 +39,15 @@ No modules.
 | [aws_account_alternate_contact.operation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/account_alternate_contact) | resource |
 | [aws_account_alternate_contact.security](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/account_alternate_contact) | resource |
 | [aws_account_primary_contact.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/account_primary_contact) | resource |
+| [aws_account_region.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/account_region) | resource |
 | [aws_iam_account_alias.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_account_alias) | resource |
 | [aws_iam_account_password_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_account_password_policy) | resource |
 | [aws_iam_security_token_service_preferences.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_security_token_service_preferences) | resource |
 | [aws_s3_account_public_access_block.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_account_public_access_block) | resource |
 | [aws_spot_datafeed_subscription.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/spot_datafeed_subscription) | resource |
+| [awscc_supportapp_account_alias.this](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/supportapp_account_alias) | resource |
+| [awscc_supportapp_slack_channel_configuration.this](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/supportapp_slack_channel_configuration) | resource |
+| [awscc_supportapp_slack_workspace_configuration.this](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/supportapp_slack_workspace_configuration) | resource |
 | [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 
 ## Inputs
@@ -49,6 +55,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_name"></a> [name](#input\_name) | (Required) The name for the AWS account. Used for the account alias. | `string` | n/a | yes |
+| <a name="input_additional_regions"></a> [additional\_regions](#input\_additional\_regions) | (Optional) A set of regions to enable in the account. | `set(string)` | `[]` | no |
 | <a name="input_billing_contact"></a> [billing\_contact](#input\_billing\_contact) | (Optional) The configuration of the billing contact for the AWS Account. `billing_contact` as defined below.<br>    (Required) `name` - The name of the billing contact.<br>    (Optional) `title` - The tile of the billing contact. Defaults to `Billing Manager`.<br>    (Required) `email` - The email address of the billing contact.<br>    (Required) `phone` - The phone number of the billing contact. | <pre>object({<br>    name  = string<br>    title = optional(string, "Billing Manager")<br>    email = string<br>    phone = string<br>  })</pre> | `null` | no |
 | <a name="input_ec2_spot_datafeed_subscription"></a> [ec2\_spot\_datafeed\_subscription](#input\_ec2\_spot\_datafeed\_subscription) | (Optional) The configuration of the Spot Data Feed Subscription. `ec2_spot_datafeed_subscription` as defined below.<br>    (Optional) `enabled` - Indicate whether to enable Spot Data Feed Subscription to S3 Bucket. Defaults to `false`.<br>    (Optional) `s3_bucket` - The configuration of the S3 bucket where AWS deliver the spot data feed. `s3_bucket` as defined below.<br>      (Required) `name` - The name of the S3 bucket where AWS deliver the spot data feed.<br>      (Optional) `key_prefix` - The path of directory inside S3 bucket to place spot pricing data. | <pre>object({<br>    enabled = optional(bool, false)<br>    s3_bucket = optional(object({<br>      name       = optional(string, "")<br>      key_prefix = optional(string, "")<br>    }))<br>  })</pre> | `{}` | no |
 | <a name="input_operation_contact"></a> [operation\_contact](#input\_operation\_contact) | (Optional) The configuration of the operation contact for the AWS Account. `operation_contact` as defined below.<br>    (Required) `name` - The name of the operation contact.<br>    (Optional) `title` - The tile of the operation contact. Defaults to `Operation Manager`.<br>    (Required) `email` - The email address of the operation contact.<br>    (Required) `phone` - The phone number of the operation contact. | <pre>object({<br>    name  = string<br>    title = optional(string, "Operation Manager")<br>    email = string<br>    phone = string<br>  })</pre> | `null` | no |
@@ -57,11 +64,13 @@ No modules.
 | <a name="input_s3_public_access_enabled"></a> [s3\_public\_access\_enabled](#input\_s3\_public\_access\_enabled) | (Optional) Whether to enable S3 account-level Public Access Block configuration. Block the public access to S3 bucket if the value is `false`. | `bool` | `false` | no |
 | <a name="input_security_contact"></a> [security\_contact](#input\_security\_contact) | (Optional) The configuration of the security contact for the AWS Account. `security_contact` as defined below.<br>    (Required) `name` - The name of the security contact.<br>    (Optional) `title` - The tile of the security contact. Defaults to `Security Manager`.<br>    (Required) `email` - The email address of the security contact.<br>    (Required) `phone` - The phone number of the security contact. | <pre>object({<br>    name  = string<br>    title = optional(string, "Security Manager")<br>    email = string<br>    phone = string<br>  })</pre> | `null` | no |
 | <a name="input_sts_global_endpoint_token_version"></a> [sts\_global\_endpoint\_token\_version](#input\_sts\_global\_endpoint\_token\_version) | (Optional) The version of the STS global endpoint token. Valid values are `v1` and<br>  `v2`. Defaults to `v1`.<br>    `v1` - Version 1 Tokens are valid only in AWS Regions that are available by default. These tokens do not work in manually enabled Regions, such as Asia Pacific (Hong Kong).<br>    `v2` - Version 2 tokens are valid in all Regions. However, version 2 tokens include more characters and might affect systems where you temporarily store tokens. | `string` | `"v1"` | no |
+| <a name="input_support_app"></a> [support\_app](#input\_support\_app) | (Optional) The configuration of the Support App for the AWS Account. `support_app` as defined below.<br>    (Optional) `account_alias` - An account alias associated with a customer's account.<br>    (Optional) `slack_workspaces` - A set of team ID for each Slack workspace, which uniquely identifies a workspace.<br>    (Optional) `slack_channel_configurations` - A list of configurations for each Slack channels. Each block of `slack_channel_configurations` as defined below.<br>      (Optional) `name` - The name of the Slack channel configuration.<br>      (Required) `workspace` - The team ID of the Slack workspace, which uniquely identifies a workspace.<br>      (Required) `channel` - The ID of the Slack channel.<br>      (Optional) `permission` - The permission of the default IAM role which created by this module. Valid values are `READ_ONLY` and `FULL_ACCESS`. Defaults to `FULL_ACCESS`.<br>      (Optional) `channel_role` - The ARN (Amazon Resource Name) of the IAM role associated with the Support App to post messages to the Slack channel. Only required to override default role which created with `permission`.<br>      (Optional) `notification_case_severity` - The severity level of the support case that a customer wants to get notified for. Valid values are `ALL`, `HIGH`, and `NONE`. Defaults to `ALL`.<br>      (Optional) `notification_on_add_correspondence_to_case` - Whether to notify when a correspondence is added to a case. Defaults to `true`.<br>      (Optional) `notification_on_create_or_reopen_case` - Whether to notify when a case is created or reopened. Defaults to `true`.<br>      (Optional) `notification_on_resolve_case` - Whether to notify when a case is resolved. Defaults to `true`. | <pre>object({<br>    account_alias    = optional(string)<br>    slack_workspaces = optional(set(string), [])<br>    slack_channel_configurations = optional(list(object({<br>      name      = optional(string)<br>      workspace = string<br>      channel   = string<br><br>      # permission   = optional(string, "FULL_ACCESS")<br>      channel_role = optional(string)<br><br>      notification_case_severity                 = optional(string, "ALL")<br>      notification_on_add_correspondence_to_case = optional(bool, true)<br>      notification_on_create_or_reopen_case      = optional(bool, true)<br>      notification_on_resolve_case               = optional(bool, true)<br>    })), [])<br>  })</pre> | `{}` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
+| <a name="output_additional_regions"></a> [additional\_regions](#output\_additional\_regions) | A set of additional regions enabled in the account. |
 | <a name="output_billing_contact"></a> [billing\_contact](#output\_billing\_contact) | The billing contact attached to an AWS Account. |
 | <a name="output_ec2"></a> [ec2](#output\_ec2) | The account-level configurations of EC2 service.<br>    `spot_datafeed_subscription` - To help you understand the charges for your Spot instances, Amazon EC2 provides a data feed that describes your Spot instance usage and pricing. This data feed is sent to an Amazon S3 bucket that you specify when you subscribe to the data feed. |
 | <a name="output_id"></a> [id](#output\_id) | The AWS Account ID. |
@@ -73,4 +82,5 @@ No modules.
 | <a name="output_security_contact"></a> [security\_contact](#output\_security\_contact) | The security contact attached to an AWS Account. |
 | <a name="output_signin_url"></a> [signin\_url](#output\_signin\_url) | The URL to signin for the AWS account. |
 | <a name="output_sts"></a> [sts](#output\_sts) | The account-level configurations of STS service.<br>    `global_endpoint_token_version` - The version of the STS global endpoint token. |
+| <a name="output_support_app"></a> [support\_app](#output\_support\_app) | The account-level configurations of Support App service.<br>    `account_alias` - The account alias associated with a customer's account. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/account/outputs.tf
+++ b/modules/account/outputs.tf
@@ -100,6 +100,34 @@ output "sts" {
   }
 }
 
+output "support_app" {
+  description = <<EOF
+  The account-level configurations of Support App service.
+    `account_alias` - The account alias associated with a customer's account.
+  EOF
+  value = {
+    account_alias    = one(awscc_supportapp_account_alias.this[*].account_alias)
+    slack_workspaces = values(awscc_supportapp_slack_workspace_configuration.this)[*].team_id
+    slack_channel_configurations = {
+      for name, configuration in awscc_supportapp_slack_channel_configuration.this :
+      name => {
+        name      = configuration.channel_name
+        workspace = configuration.team_id
+        channel   = configuration.channel_id
+
+        channel_role = {
+          arn = configuration.channel_role_arn
+        }
+
+        notification_case_severity                 = upper(configuration.notify_on_case_severity)
+        notification_on_add_correspondence_to_case = configuration.notify_on_add_correspondence_to_case
+        notification_on_create_or_reopen_case      = configuration.notify_on_create_or_reopen_case
+        notification_on_resolve_case               = configuration.notify_on_resolve_case
+      }
+    }
+  }
+}
+
 output "s3" {
   description = <<EOF
   The account-level configurations of S3 service.

--- a/modules/account/support-app.tf
+++ b/modules/account/support-app.tf
@@ -1,0 +1,50 @@
+###################################################
+# Account Alias for Support App
+###################################################
+
+resource "awscc_supportapp_account_alias" "this" {
+  count = var.support_app.account_alias != null ? 1 : 0
+
+  account_alias = var.support_app.account_alias
+}
+
+
+###################################################
+# Slack Workspace Authorization for Support App
+###################################################
+
+# INFO: Not supported attributes
+# - `version_id`
+resource "awscc_supportapp_slack_workspace_configuration" "this" {
+  for_each = var.support_app.slack_workspaces
+
+  team_id = each.value
+}
+
+
+###################################################
+# Slack Workspace Authorization for Support App
+###################################################
+
+resource "awscc_supportapp_slack_channel_configuration" "this" {
+  for_each = {
+    for configuration in var.support_app.slack_channel_configurations :
+    configuration.name => configuration
+  }
+
+  channel_name = each.key
+  team_id      = awscc_supportapp_slack_workspace_configuration.this[each.value.workspace].team_id
+  channel_id   = each.value.channel
+
+
+  ## Permissions
+  # TODO: Use default role with `permission` variable
+  channel_role_arn = each.value.channel_role
+
+
+  ## Notification
+  notify_on_case_severity              = lower(each.value.notification_case_severity)
+  notify_on_add_correspondence_to_case = each.value.notification_on_add_correspondence_to_case
+  notify_on_create_or_reopen_case      = each.value.notification_on_create_or_reopen_case
+  notify_on_resolve_case               = each.value.notification_on_resolve_case
+}

--- a/modules/account/versions.tf
+++ b/modules/account/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 5.10"
     }
+    awscc = {
+      source  = "hashicorp/awscc"
+      version = ">= 0.75"
+    }
   }
 }


### PR DESCRIPTION
### :wave: Background
<!-- Please explain the background or motivation for this change. -->

- Support support-app slack in account module
- Implemented by using `awscc` provider