### PR TITLE
fix(iam-predefined-policies): correct stale actions in self-service policies

### DIFF
--- a/modules/iam-predefined-policies/policies/self-service-access-key.json
+++ b/modules/iam-predefined-policies/policies/self-service-access-key.json
@@ -7,8 +7,9 @@
       "Action": [
         "iam:CreateAccessKey",
         "iam:ListAccessKeys",
-        "iam:UpdateAccessKeys",
-        "iam:DeleteAccessKey"
+        "iam:UpdateAccessKey",
+        "iam:DeleteAccessKey",
+        "iam:GetAccessKeyLastUsed"
       ],
       "Resource": [
         "arn:aws:iam::*:user/${aws:username}",

--- a/modules/iam-predefined-policies/policies/self-service-mfa.json
+++ b/modules/iam-predefined-policies/policies/self-service-mfa.json
@@ -8,18 +8,36 @@
       "Resource": "*"
     },
     {
+      "Sid": "AllowIndividualUserToCreateTheirOwnVirtualMFA",
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreateVirtualMFADevice"
+      ],
+      "Resource": [
+        "arn:aws:iam::*:mfa/*"
+      ]
+    },
+    {
+      "Sid": "AllowIndividualUserToDeleteOnlyTheirOwnVirtualMFA",
+      "Effect": "Allow",
+      "Action": [
+        "iam:DeleteVirtualMFADevice"
+      ],
+      "Resource": [
+        "arn:aws:iam::*:mfa/${aws:username}"
+      ]
+    },
+    {
       "Sid": "AllowIndividualUserToManageTheirOwnMFA",
       "Effect": "Allow",
       "Action": [
-        "iam:CreateVirtualMFADevice",
-        "iam:DeleteVirtualMFADevice",
         "iam:EnableMFADevice",
+        "iam:GetMFADevice",
         "iam:GetUser",
         "iam:ListMFADevices",
         "iam:ResyncMFADevice"
       ],
       "Resource": [
-        "arn:aws:iam::*:mfa/*",
         "arn:aws:iam::*:user/${aws:username}",
         "arn:aws:iam::*:user/*/${aws:username}"
       ]
@@ -31,8 +49,8 @@
         "iam:DeactivateMFADevice"
       ],
       "Resource": [
-        "arn:aws:iam::*:mfa/*",
-        "arn:aws:iam::*:user/${aws:username}"
+        "arn:aws:iam::*:user/${aws:username}",
+        "arn:aws:iam::*:user/*/${aws:username}"
       ],
       "Condition": {
         "Bool": {
@@ -48,8 +66,12 @@
         "iam:GetAccountSummary",
         "iam:GetUser",
         "iam:ChangePassword",
+        "iam:CreateLoginProfile",
+        "iam:GetLoginProfile",
+        "iam:UpdateLoginProfile",
         "iam:CreateVirtualMFADevice",
         "iam:EnableMFADevice",
+        "iam:GetMFADevice",
         "iam:ListMFADevices",
         "iam:ListVirtualMFADevices",
         "iam:ResyncMFADevice",


### PR DESCRIPTION
## Summary

The `self-service-*` predefined policies had drifted from the current [AWS IAM reference policies](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_aws_my-sec-creds-self-manage.html). This validates all four against the current docs and fixes five issues — one of which silently granted nothing, and one of which made `self-service-password` and `self-service-mfa` mutually incompatible.

Found while debugging a real failure: a new IAM user with all three `self-service-*` policies attached could not complete self-service password management before enrolling an MFA device.

## Changes

### `self-service-access-key`

| | |
|---|---|
| `iam:UpdateAccessKeys` → `iam:UpdateAccessKey` | The plural form is not a real IAM action. IAM accepts well-formed but unknown `service:Action` strings without error, so this **silently granted nothing** — users could not activate/deactivate their own access keys. Confirmed by `accessanalyzer validate-policy` (see Verification). |
| add `iam:GetAccessKeyLastUsed` | Required for the console to render the "Last used" column. Present in the AWS reference policy. |

### `self-service-mfa`

| | |
|---|---|
| add `iam:CreateLoginProfile`, `iam:GetLoginProfile`, `iam:UpdateLoginProfile` to `DenyAllExceptListedIfNoMFA` | **The main fix.** `self-service-password` *grants* these three actions, but this policy's deny statement blocked them for any principal without MFA. Attaching both policies to the same user — the intended combination — silently broke self-service password management until the user enrolled MFA. |
| add `iam:GetMFADevice` (allow + `NotAction`) | AWS added this to its reference policy for the FIDO/passkey enrollment flow. |
| scope `iam:DeleteVirtualMFADevice` to `mfa/${aws:username}` | Was granted on `mfa/*`, letting any user delete **another** user's unassigned virtual MFA device. |
| scope `iam:DeactivateMFADevice` + remaining MFA actions to user ARNs | The `mfa/*` resource was never required for these; the AWS reference scopes them to `user/${aws:username}`. |

`self-service-password` and `self-service-ssh-public-key` needed no changes — all action names and resource scopes match the current reference policies.

## Tradeoffs worth reviewing

1. **Login profile actions in `NotAction` weaken MFA enforcement.** AWS notes that allowing password changes without MFA "can be a security risk" and instead recommends not granting permissions to new users until after they sign in. But since `self-service-password` already grants these actions on the user's own ARN, the previous state was strictly worse: the grant existed and was silently dead. This makes the intent explicit. If you'd prefer stricter enforcement, the alternative is to *remove* the login profile statement from `self-service-password` instead — happy to switch.

2. **`DeleteVirtualMFADevice` now depends on device naming.** Scoping to `mfa/${aws:username}` assumes the virtual MFA device is named after the user, which is the console default. A user who renames their device cannot delete it themselves. Per AWS guidance this is the intended failure mode — an administrator resolves leftover unassigned devices, and non-MFA users should never be able to delete an MFA device.

## Verification

`accessanalyzer validate-policy` (`IDENTITY_POLICY`) against the real AWS API:

```
# before — original self-service-access-key.json
INVALID_ACTION   ERROR

# after — all four policies
self-service-access-key.json      (no findings)
self-service-mfa.json             (no findings)
self-service-password.json        (no findings)
self-service-ssh-public-key.json  (no findings)
```

All four now return zero findings — no errors, warnings, or suggestions. JSON syntax validated separately.

Not covered: no live console walkthrough of the first-sign-in reset or MFA enrollment flow against a test user. The `DeleteVirtualMFADevice` naming assumption in particular is documentation-derived and untested end-to-end.

## Compatibility

Consumers pinned to `~> 0.33.x` pick this up on the next patch release. The change is not purely additive — three MFA actions lose the `mfa/*` resource and `DeleteVirtualMFADevice` narrows — so anyone relying on cross-user MFA device deletion (unlikely, and unsafe) would see a behavior change.
