### PR TITLE
fix(iam-predefined-policies): drop `iam:DeleteVirtualMFADevice` from self-service-mfa

### DIFF
--- a/modules/iam-predefined-policies/policies/self-service-mfa.json
+++ b/modules/iam-predefined-policies/policies/self-service-mfa.json
@@ -18,16 +18,6 @@
       ]
     },
     {
-      "Sid": "AllowIndividualUserToDeleteOnlyTheirOwnVirtualMFA",
-      "Effect": "Allow",
-      "Action": [
-        "iam:DeleteVirtualMFADevice"
-      ],
-      "Resource": [
-        "arn:aws:iam::*:mfa/${aws:username}"
-      ]
-    },
-    {
       "Sid": "AllowIndividualUserToManageTheirOwnMFA",
       "Effect": "Allow",
       "Action": [


### PR DESCRIPTION
## Summary

Follow-up to #132. Removes the `iam:DeleteVirtualMFADevice` grant from `self-service-mfa` entirely, rather than scoping it to `mfa/${aws:username}`.

```diff
-    {
-      "Sid": "AllowIndividualUserToDeleteOnlyTheirOwnVirtualMFA",
-      "Effect": "Allow",
-      "Action": [
-        "iam:DeleteVirtualMFADevice"
-      ],
-      "Resource": [
-        "arn:aws:iam::*:mfa/${aws:username}"
-      ]
-    },
```

## Why

- The [AWS reference policy](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_aws_my-sec-creds-self-manage-mfa-only.html) does not grant this action at all. This brings the policy in line with it.
- The scoped version from #132 depended on the virtual MFA device being named after the user. That is only the console default — a user who renames their device silently loses the permission, so the grant was unreliable in exactly the case it was meant to cover.

## Behavior change

A user who cancels virtual MFA enrollment midway will get an `iam:DeleteVirtualMFADevice` access denied error when they retry, because the earlier attempt left an unassigned device behind. Per AWS guidance this is the intended failure mode:

> Do not add permission to delete an MFA device without MFA authentication. […] If this happens, **do not** add that permission to the `DenyAllExceptListedIfNoMFA` statement. Users that are not authenticated using MFA should never be allowed to delete their MFA device. […] To resolve this issue, you or another administrator must delete the user's existing virtual MFA device using the AWS CLI or AWS API.

Admin remedy:

```
aws iam delete-virtual-mfa-device --serial-number arn:aws:iam::<account>:mfa/<device-name>
```

Worth noting in your onboarding runbook if IAM users self-enroll MFA.

## Verification

`accessanalyzer validate-policy` (`IDENTITY_POLICY`) against the real AWS API returns zero findings — no errors, warnings, or suggestions. JSON syntax validated. No residual `DeleteVirtualMFADevice` references anywhere under `modules/`.

Not covered: no live console walkthrough of the cancel-then-retry enrollment path.

## Note

The `tflint` failure on `modules/iam-predefined-policies/versions.tf` (`terraform_unused_required_providers` on `aws`) is pre-existing and unrelated — it predates #132 and is left as-is by request.
