### PR TITLE
chore(deps): align tedilabs child module version constraints with latest releases

### DIFF
--- a/examples/account-alias/main.tf
+++ b/examples/account-alias/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
 module "account" {
   source = "../../modules/account"
   # source  = "tedilabs/account/aws//modules/account"
-  # version = "~> 0.26.0"
+  # version = "~> 0.33.0"
 
   # This is alias for the AWS account.
   name = "example-210925"

--- a/examples/account-contacts/main.tf
+++ b/examples/account-contacts/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
 module "account" {
   source = "../../modules/account"
   # source  = "tedilabs/account/aws//modules/account"
-  # version = "~> 0.26.0"
+  # version = "~> 0.33.0"
 
   # This is alias for the AWS account.
   name = "example-210925"

--- a/examples/account-password-policy/main.tf
+++ b/examples/account-password-policy/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
 module "account" {
   source = "../../modules/account"
   # source  = "tedilabs/account/aws//modules/account"
-  # version = "~> 0.26.0"
+  # version = "~> 0.33.0"
 
   # This is alias for the AWS account.
   name = "example-210925"

--- a/examples/github-trusted-iam-roles/main.tf
+++ b/examples/github-trusted-iam-roles/main.tf
@@ -19,7 +19,7 @@ locals {
 module "oidc_provider" {
   source = "../../modules/iam-oidc-identity-provider"
   # source  = "tedilabs/account/aws//modules/iam-oidc-identity-provider"
-  # version = "~> 0.23.0"
+  # version = "~> 0.33.0"
 
   for_each = {
     for provider in try(local.providers, []) :
@@ -54,7 +54,7 @@ locals {
 module "role" {
   source = "../../modules/iam-role"
   # source  = "tedilabs/account/aws//modules/iam-role"
-  # version = "~> 0.23.0"
+  # version = "~> 0.33.0"
 
   for_each = {
     for role in try(local.roles, []) :

--- a/examples/iam-oidc-identity-providers/main.tf
+++ b/examples/iam-oidc-identity-providers/main.tf
@@ -19,7 +19,7 @@ locals {
 module "oidc_provider" {
   source = "../../modules/iam-oidc-identity-provider"
   # source  = "tedilabs/account/aws//modules/iam-oidc-identity-provider"
-  # version = "~> 0.23.0"
+  # version = "~> 0.33.0"
 
   for_each = {
     for provider in try(local.providers, []) :

--- a/examples/iam-saml-identity-providers/main.tf
+++ b/examples/iam-saml-identity-providers/main.tf
@@ -19,7 +19,7 @@ locals {
 module "saml_provider" {
   source = "../../modules/iam-saml-identity-provider"
   # source  = "tedilabs/account/aws//modules/iam-saml-identity-provider"
-  # version = "~> 0.23.0"
+  # version = "~> 0.33.0"
 
   for_each = {
     for provider in try(local.providers, []) :


### PR DESCRIPTION
## 1. What & why

The commented-out registry alternatives in `examples/` still advertise `~> 0.23.0` / `~> 0.26.0` of this repo's own modules, while the repo is now at **v0.33.10**. Anyone copy-pasting an example into their own root module would pin a constraint that is seven-to-ten minor versions behind, and — for `iam-role` — one whose interface no longer matches the example code sitting right underneath it.

This realigns all seven lines to the house `~> MAJOR.MINOR.0` convention (`~> 0.33.0`). These are self-references: the target repo is this repo.

## 2. Changed constraints

There are **no active `module` blocks** to change in this PR. Every example's live `source` is a local `../../modules/<x>` path that already tracks HEAD, so there is no cross-repo interface risk here.

### Example docs (commented)

| Child module | Path | Before | After | Latest release |
|---|---|---|---|---|
| `tedilabs/account/aws//modules/account` | `examples/account-alias/main.tf:13` | `~> 0.26.0` | `~> 0.33.0` | `v0.33.10` |
| `tedilabs/account/aws//modules/account` | `examples/account-contacts/main.tf:13` | `~> 0.26.0` | `~> 0.33.0` | `v0.33.10` |
| `tedilabs/account/aws//modules/account` | `examples/account-password-policy/main.tf:13` | `~> 0.26.0` | `~> 0.33.0` | `v0.33.10` |
| `tedilabs/account/aws//modules/iam-oidc-identity-provider` | `examples/github-trusted-iam-roles/main.tf:22` | `~> 0.23.0` | `~> 0.33.0` | `v0.33.10` |
| `tedilabs/account/aws//modules/iam-role` | `examples/github-trusted-iam-roles/main.tf:57` | `~> 0.23.0` | `~> 0.33.0` | `v0.33.10` |
| `tedilabs/account/aws//modules/iam-oidc-identity-provider` | `examples/iam-oidc-identity-providers/main.tf:22` | `~> 0.23.0` | `~> 0.33.0` | `v0.33.10` |
| `tedilabs/account/aws//modules/iam-saml-identity-provider` | `examples/iam-saml-identity-providers/main.tf:22` | `~> 0.23.0` | `~> 0.33.0` | `v0.33.10` |

## 3. Interface changes between the old and new versions

**These are documentation-only comment lines.** Terraform never parses them, so this PR cannot change any plan, and no calling code needed to change. The summary below is for readers who follow the commented `source`/`version` into their own root module — for them the drift is real and large.

Compare URL for the `account` range: <https://github.com/tedilabs/terraform-aws-account/compare/v0.26.0...v0.33.10>
Compare URL for the `iam-*` ranges: <https://github.com/tedilabs/terraform-aws-account/compare/v0.23.0...v0.33.10>

### `modules/account` — v0.26.0 -> v0.33.10

Verdict: **ACTION_REQUIRED for external callers** (no-op here).

- Renamed/retyped: the three flat `ec2_spot_datafeed_subscription_{enabled,s3_bucket,s3_prefix}` variables were folded into a single `ec2_spot_datafeed_subscription` object.
- Added variables: `additional_regions`, `cost`, `cost_optimization_hub`, `primary_contact`, `sts_global_endpoint_token_version`, `support_app`, `user_notifications`, `uxc`.
- Added outputs: `additional_regions`, `all_available_regions`, `cost`, `cost_optimization_hub`, `primary_contact`, `sts`, `support_app`, `user_notifications`, `uxc`. No output removed or renamed.
- New version floors: Terraform `>= 1.3` -> **`>= 1.12`**; `hashicorp/aws` `>= 4.19` -> **`>= 6.39`**; and a **new required provider `hashicorp/awscc >= 1.55`**.

### `modules/iam-role` — v0.23.0 -> v0.33.10

Verdict: **ACTION_REQUIRED for external callers** (no-op here). This is by far the largest drift of the four.

- Renamed variables (hard `terraform plan` failures if the old names are passed):
  `trusted_iam_entities` -> `trusted_iam_entity_policies`, `trusted_oidc_providers` -> `trusted_oidc_provider_policies`, `trusted_saml_providers` -> `trusted_saml_provider_policies`, `trusted_services` -> `trusted_service_policies`.
- Flattened-to-object migrations: `instance_profile_enabled` -> `instance_profile` object (`enabled`/`name`/`path`/`tags`); `resource_group_{enabled,name,description}` -> `resource_group` object. Note the instance profile's `path` **no longer inherits the role's `path`** — it defaults to `/` independently, and `path` is force-new on `aws_iam_instance_profile`.
- Removed variables: `effective_date`, `expiration_date`, `mfa_required`, `mfa_ttl`, `source_ip_blacklist`, `source_ip_whitelist`.
- Added variables: `exclusive_policy_management_enabled`, `exclusive_inline_policy_management_enabled`, `trusted_session_tagging`, `trusted_source_identity` (all defaulted; leaving them unset reproduces the old behaviour).
- Removed outputs: `instance_profile_name` / `instance_profile_arn` / `instance_profile_unique_id`, replaced by a single `instance_profile` **object** output (`.name` / `.arn` / `.id`, and `null` as a whole when the profile is disabled). Also removed: `effective_date`, `expiration_date`, `mfa_required`, `mfa_ttl`, `source_ip_blacklist`, `source_ip_whitelist`.
- Retyped outputs: `assumable_roles`, `policies`, `inline_policies` are now **sets, not lists** — index access (`[0]`) or splat-ordering assumptions break. `policies` is now derived from real resource attributes, so it is `(known after apply)` and must not feed a `for_each`/`count`.
- Behavioural: the generated `assume_role` inline policy widened from `sts:AssumeRole` to also grant `sts:TagSession` and `sts:SetSourceIdentity`.
- New version floors: Terraform `>= 1.3` -> **`>= 1.12`**; `hashicorp/aws` `>= 3.45` -> **`>= 6.12`**.

### `modules/iam-oidc-identity-provider` — v0.23.0 -> v0.33.10

Verdict: **ACTION_REQUIRED for external callers** (no-op here).

- Renamed: `resource_group_{enabled,name,description}` -> `resource_group` object.
- Added output `urn` (the URL with the scheme stripped) and `resource_group`. **Retyped output `url`**: it now returns `var.url` verbatim rather than the provider's normalised `aws_iam_openid_connect_provider.this.url` — i.e. it keeps the `https://` prefix that the resource attribute strips. Callers relying on the old scheme-less value should switch to the new `urn` output.
- New version floors: Terraform `>= 1.3` -> **`>= 1.12`**; `hashicorp/aws` `>= 4.36` -> **`>= 6.12`**; `hashicorp/tls` `>= 4.0` -> **`>= 4.1`**.

### `modules/iam-saml-identity-provider` — v0.23.0 -> v0.33.10

Verdict: **ACTION_REQUIRED for external callers** (no-op here). Smallest drift of the four.

- Renamed: `resource_group_{enabled,name,description}` -> `resource_group` object. `name` gained `nullable = false` (it was already required).
- Added output `resource_group`. No output removed or renamed.
- New version floors: Terraform `>= 1.3` -> **`>= 1.12`**; `hashicorp/aws` -> **`>= 6.12`**.

### Related, but deliberately not touched here

`modules/ram-share` was **deleted from this repo in v0.29.0** and migrated to `terraform-aws-organization` (commit `e8e500a`). Nothing in this repo references it, so there is nothing to fix here. Several other tedilabs repos still point at `tedilabs/account/aws//modules/ram-share` at `~> 0.23.0` / `~> 0.27.0` and would fail `terraform init` against `~> 0.33.0`; those are being repointed to `tedilabs/organization/aws//modules/ram-share` in separate PRs.

## 4. Verification

- `terraform fmt -recursive -check .` — **pass** (before and after).
- **Did the `iam-role` interface drift actually break the example?** No. This was worth checking, because `examples/github-trusted-iam-roles` calls the *local* `../../modules/iam-role`, so a stale example would be a genuine bug rather than a stale comment. It is already written against the current interface: it passes `trusted_oidc_provider_policies` (the new name), never sets `instance_profile_*` or `resource_group_*`, and re-exports whole module objects rather than index-accessing the now-set-typed `policies` / `assumable_roles` / `inline_policies` outputs. No example code needed changing.
- `terraform init -backend=false && terraform validate` — **`Success! The configuration is valid.` in all 6 touched example dirs**: `account-alias`, `account-contacts`, `account-password-policy`, `github-trusted-iam-roles`, `iam-oidc-identity-providers`, `iam-saml-identity-providers`.
- All `.terraform/` dirs and `.terraform.lock.hcl` files created during validation were removed; `git status` is clean apart from the seven comment lines.

### Caveat on how validation had to be run — pre-existing breakage on `main`

Out of the box, **`terraform init` fails in all 6 example dirs on `main` today**, independently of this PR:

```
Error: Failed to query available provider packages
Could not retrieve the list of available versions for provider hashicorp/aws:
no available releases match the given constraints ~> 5.0, >= 6.39.0
```

Each `examples/*/versions.tf` still pins `aws = "~> 5.0"`, while the local modules they call now require `>= 6.12` (`iam-*`) and `>= 6.39` + `awscc >= 1.55` (`account`). All 6 of 6 example dirs are affected. To validate, I applied a **temporary, uncommitted** `required_providers` override raising `aws` to `>= 6.39.0` in each dir, then deleted it — so the `validate` results above are honest proof that the example *configurations* match the module interfaces, but they were not obtained with the provider constraints as currently committed.

Fixing those `versions.tf` pins is a real bug but is out of scope for a comment-only dependency PR, so I have left them alone. **Recommended follow-up: bump `aws = "~> 5.0"` -> `"~> 6.0"` in all six `examples/*/versions.tf`, add the `awscc` requirement to the three `account` examples, and raise `required_version` from `~> 1.5` to `>= 1.12`.**

One more note for reproducibility: `terraform validate` intermittently failed with `Unrecognized remote plugin message / Failed to read any lines from plugin's stdout` on a freshly downloaded `hashicorp/aws` v6.58.0. That is a cold-start handshake timeout on the 820 MB provider binary, not a configuration problem — re-running after the binary was warm in the page cache succeeded deterministically. Nothing to do with this change.

## 5. Supersedes

**No open dependabot PR is superseded by this one.**

There are four open dependabot PRs touching tedilabs child modules in this repo — #115, #93, #89, #88 — but they all target a *different* constraint (`tedilabs/misc/aws` `~> 0.10.0` -> `~> 0.11.0`) that this PR does not touch. All four are already obsolete on `main`, for two independent reasons:

- Every `tedilabs/misc/aws//modules/resource-group` reference in `modules/` is **already at `~> 0.12.0`**, i.e. ahead of the `~> 0.11.0` these PRs propose. That applies to #115's target, `modules/region`, which still exists.
- #93, #89 and #88 target `modules/sso-permission-set`, `modules/org-account` and `modules/org-organizational-unit` — directories **removed from this repo in v0.29.0** by the same migration to `terraform-aws-organization` that removed `ram-share`.

So all four are stale on their own merit and can be closed independently. This is also why this PR has no active `module` block edits: there is no remaining `tedilabs/*` constraint in `modules/` that is behind.

Per instruction, **no dependabot PR is closed by this change.** The other two open PRs (#126, #125) are GitHub Actions bumps and unrelated.
