### PR TITLE
fix(examples): correct terraform and provider version constraints

### DIFF
--- a/examples/account-alias/versions.tf
+++ b/examples/account-alias/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/account-contacts/versions.tf
+++ b/examples/account-contacts/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/account-password-policy/versions.tf
+++ b/examples/account-password-policy/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/github-trusted-iam-roles/versions.tf
+++ b/examples/github-trusted-iam-roles/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/iam-oidc-identity-providers/versions.tf
+++ b/examples/iam-oidc-identity-providers/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/iam-saml-identity-providers/versions.tf
+++ b/examples/iam-saml-identity-providers/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
 }


### PR DESCRIPTION
## What & why

Every one of the 6 example roots in this repo pins `hashicorp/aws = "~> 5.0"`, an upper bound
below what its own local modules require. Terraform intersects the root constraint with the child
module constraints, the intersection is empty, and `terraform init` hard-fails — so none of these
examples can be initialised at all. Verbatim, from `examples/account-alias` on `main`:

```
Error: Failed to query available provider packages

Could not retrieve the list of available versions for provider hashicorp/aws:
no available releases match the given constraints ~> 5.0, >= 6.39.0
```

This PR raises the constraints so the examples resolve again. It touches only
`examples/*/versions.tf`.

## Convention applied

- terraform: `required_version = "~> x.y"` → `~> 1.12`
- providers: `version = "~> x.0"` → `~> 6.0`

`~> 6.0` is sufficient even though `modules/account` declares `>= 6.39`: Terraform intersects all
constraints in the graph, so `~> 6.0` ∩ `>= 6.39` = `[6.39, 7.0)`. The module floor is deliberately
not copied into the roots.

## Changed roots

| Example root | `required_version` before → after | `aws` before → after | Why |
| --- | --- | --- | --- |
| `examples/account-alias` | `~> 1.5` → `~> 1.12` | `~> 5.0` → `~> 6.0` | conflict — `modules/account` needs `>= 6.39` |
| `examples/account-contacts` | `~> 1.5` → `~> 1.12` | `~> 5.0` → `~> 6.0` | conflict — `modules/account` needs `>= 6.39` |
| `examples/account-password-policy` | `~> 1.5` → `~> 1.12` | `~> 5.0` → `~> 6.0` | conflict — `modules/account` needs `>= 6.39` |
| `examples/github-trusted-iam-roles` | `~> 1.5` → `~> 1.12` | `~> 5.0` → `~> 6.0` | conflict — `modules/iam-oidc-identity-provider` needs `>= 6.12` |
| `examples/iam-oidc-identity-providers` | `~> 1.5` → `~> 1.12` | `~> 5.0` → `~> 6.0` | conflict — `modules/iam-oidc-identity-provider` needs `>= 6.12` |
| `examples/iam-saml-identity-providers` | `~> 1.5` → `~> 1.12` | `~> 5.0` → `~> 6.0` | conflict — `modules/iam-saml-identity-provider` needs `>= 6.12` |

6 init-breaking conflicts, 0 style-only violations.

## Added missing provider declaration

**None was needed.** This was investigated explicitly and the expected problem did not
materialise, so it is worth recording the negative result.

`modules/account` requires a second provider that none of the three roots going through it
(`account-alias`, `account-contacts`, `account-password-policy`) declare:

```hcl
awscc = {
  source  = "hashicorp/awscc"
  version = ">= 1.55"
}
```

The concern was that an undeclared provider required by a child module would make `init` fail in a
different way. It does not. Terraform collects `required_providers` transitively from the whole
module graph, so `init` discovers and installs `awscc` from the child module's declaration and
passes the implicit default provider configuration down. Observed on `examples/account-alias`:

```
Initializing provider plugins found in the configuration...
- Finding hashicorp/awscc versions matching ">= 1.55.0"...
- Finding hashicorp/aws versions matching "~> 6.0, >= 6.39.0"...
- Installing hashicorp/awscc v1.96.0...
- Installing hashicorp/aws v6.58.0...

Terraform has been successfully initialized!
```

`terraform validate` also passes on all three. The same applies to `hashicorp/tls`, which
`modules/iam-oidc-identity-provider` requires (`>= 4.1`) and which
`examples/github-trusted-iam-roles` and `examples/iam-oidc-identity-providers` likewise do not
declare — it resolves to v4.3.0 transitively and validates.

No `awscc` or `tls` block was therefore added. Adding one would have declared a provider the roots
do not themselves use, for no functional gain.

## Verification

`terraform fmt -recursive -check .` — passes.

Per root, with an isolated `TF_PLUGIN_CACHE_DIR`, run serially,
`terraform init -backend=false && terraform validate`:

| Example root | Result |
| --- | --- |
| `examples/account-alias` | init OK, validate OK |
| `examples/account-contacts` | init OK, validate OK |
| `examples/account-password-policy` | init OK, validate OK |
| `examples/github-trusted-iam-roles` | init OK, validate OK |
| `examples/iam-oidc-identity-providers` | init OK, validate OK |
| `examples/iam-saml-identity-providers` | init OK, validate OK |

All 6 resolved `hashicorp/aws` to v6.58.0.

Two transient `Failed to load plugin schemas` / cached-package-checksum errors were hit during the
sweep. Both were environmental (a shared plugin cache being written concurrently), not
configuration problems: re-running `init` in a clean directory produced `validate` success with no
code change. `.terraform/` and `.terraform.lock.hcl` were removed from every directory touched.

## Pre-existing failures newly exposed

**None.** Fixing `init` in these 6 roots did not uncover any stale HCL — every root that now
reaches `validate` passes it. CI should be green for all 6.

## Related PRs

Open PRs in this repo, and how they relate:

- **#134** `chore(deps): align tedilabs child module version constraints with latest releases`
  (`chore/deps-align-child-module-versions`) — touches only `examples/*/main.tf`. Confirmed with
  `git diff --name-only origin/main origin/chore/deps-align-child-module-versions`, which lists six
  `main.tf` paths and no `versions.tf`. File sets are disjoint; no conflict either way.
- **#126** `chore(deps): bump actions/checkout from 4 to 6` — dependabot, `.github/` only.
- **#125** `chore(deps): bump tj-actions/changed-files from 44 to 47` — dependabot, `.github/` only.

There is no open `docs/align-readme-example-versions` PR in this repo.
